### PR TITLE
fix: <b64enc>: wrong type for value; expected string; got map[string]…

### DIFF
--- a/charts/draupnir/templates/secret.yaml
+++ b/charts/draupnir/templates/secret.yaml
@@ -4,5 +4,6 @@ metadata:
   name: {{ include "draupnir.fullname" . }}-config-secret
   labels:
     {{- include "draupnir.labels" . | nindent 4 }}
-data:
-    config.yaml: {{ .Values.config | b64enc | quote }}
+stringData:
+    config.yaml: |
+      {{ .Values.config | toYaml | nindent 6 }}


### PR DESCRIPTION
It can be a stringData instead, there is no need for base64 encoding.